### PR TITLE
VertxApplication main should not print usage on application failure

### DIFF
--- a/application/src/main/java/io/vertx/launcher/application/ExitCodes.java
+++ b/application/src/main/java/io/vertx/launcher/application/ExitCodes.java
@@ -13,6 +13,8 @@ package io.vertx.launcher.application;
 
 public class ExitCodes {
 
+  public static final int SOFTWARE = 1;
+  public static final int USAGE = 2;
   public static final int VERTX_INITIALIZATION = 11;
   public static final int VERTX_DEPLOYMENT = 15;
 

--- a/application/src/main/java/io/vertx/launcher/application/VertxApplication.java
+++ b/application/src/main/java/io/vertx/launcher/application/VertxApplication.java
@@ -13,7 +13,7 @@ package io.vertx.launcher.application;
 
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
-import io.vertx.launcher.application.impl.CommandException;
+import io.vertx.launcher.application.impl.CommandExceptionHandler;
 import io.vertx.launcher.application.impl.VertxApplicationCommand;
 import picocli.CommandLine;
 
@@ -97,9 +97,9 @@ public class VertxApplication {
     VertxApplicationCommand command = new VertxApplicationCommand(this, Objects.requireNonNull(hooks), log);
     CommandLine commandLine = new CommandLine(command)
       .setOptionsCaseInsensitive(true)
-      .setExitCodeExceptionMapper(CommandException.EXIT_CODE_EXCEPTION_MAPPER);
+      .setExecutionExceptionHandler(new CommandExceptionHandler());
     int exitCode = commandLine.execute(args);
-    if (exitCode != 0) {
+    if (exitCode == ExitCodes.USAGE) {
       if (printUsageOnFailure) {
         CommandLine.usage(command, System.out, Ansi.ON);
       }

--- a/application/src/main/java/io/vertx/launcher/application/impl/CommandException.java
+++ b/application/src/main/java/io/vertx/launcher/application/impl/CommandException.java
@@ -12,22 +12,20 @@
 package io.vertx.launcher.application.impl;
 
 import io.vertx.core.VertxException;
-import picocli.CommandLine.IExitCodeExceptionMapper;
 
+/**
+ * An exception than can be thrown to interrupt the processing of {@link VertxApplicationCommand} and specify which exit code should be used.
+ */
 public class CommandException extends VertxException {
-
-  public static final IExitCodeExceptionMapper EXIT_CODE_EXCEPTION_MAPPER = t -> {
-    if (t instanceof CommandException) {
-      CommandException commandException = (CommandException) t;
-      return commandException.code;
-    }
-    return 1;
-  };
 
   private final int code;
 
   public CommandException(int code) {
     super((String) null, true);
     this.code = code;
+  }
+
+  public int getCode() {
+    return code;
   }
 }

--- a/application/src/main/java/io/vertx/launcher/application/impl/CommandExceptionHandler.java
+++ b/application/src/main/java/io/vertx/launcher/application/impl/CommandExceptionHandler.java
@@ -1,0 +1,19 @@
+package io.vertx.launcher.application.impl;
+
+import io.vertx.launcher.application.ExitCodes;
+import picocli.CommandLine;
+
+import static picocli.CommandLine.IExecutionExceptionHandler;
+import static picocli.CommandLine.ParseResult;
+
+public class CommandExceptionHandler implements IExecutionExceptionHandler {
+
+  @Override
+  public int handleExecutionException(Exception ex, CommandLine commandLine, ParseResult parseResult) {
+    if (ex instanceof CommandException) {
+      CommandException commandException = (CommandException) ex;
+      return commandException.getCode();
+    }
+    return ExitCodes.SOFTWARE;
+  }
+}

--- a/application/src/test/java/io/vertx/launcher/application/VertxApplicationTest.java
+++ b/application/src/test/java/io/vertx/launcher/application/VertxApplicationTest.java
@@ -18,8 +18,8 @@ import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.metrics.MetricsOptions;
 import io.vertx.core.spi.VertxServiceProvider;
-import io.vertx.test.fakecluster.FakeClusterManager;
 import io.vertx.test.TestVerticle;
+import io.vertx.test.fakecluster.FakeClusterManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.vertx.core.ThreadingModel.*;
+import static io.vertx.launcher.application.ExitCodes.USAGE;
 import static io.vertx.launcher.application.ExitCodes.VERTX_DEPLOYMENT;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
@@ -119,13 +120,24 @@ public class VertxApplicationTest {
   }
 
   @Test
+  public void testUsageDisplayedWhenInputIsInvalid() throws Exception {
+    Integer exitCode = captureOutput(() -> {
+      TestVertxApplication app = new TestVertxApplication(new String[]{"-instances", "BOOM", HttpTestVerticle.class.getName()}, hooks);
+      return app.launch();
+    });
+    assertEquals(USAGE, exitCode);
+    assertTrue(out.toString().contains("Usage:"));
+    assertTrue(err.toString().contains("BOOM"));
+  }
+
+  @Test
   public void testFailureWhenBothWorkerAndVirtualOptionsAreSet() throws Exception {
     Integer exitCode = captureOutput(() -> {
       TestVertxApplication app = new TestVertxApplication(new String[]{"-vt", "-w", HttpTestVerticle.class.getName()}, hooks);
       return app.launch();
     });
     assertEquals(VERTX_DEPLOYMENT, exitCode);
-    assertTrue(out.toString().contains("Usage:"));
+    assertFalse(out.toString().contains("Usage:"));
     assertTrue(err.toString().contains("threading model"));
   }
 
@@ -145,7 +157,7 @@ public class VertxApplicationTest {
       return app.launch();
     });
     assertEquals(VERTX_DEPLOYMENT, exitCode);
-    assertTrue(out.toString().contains("Usage:"));
+    assertFalse(out.toString().contains("Usage:"));
   }
 
   @Test
@@ -156,7 +168,7 @@ public class VertxApplicationTest {
       return app.launch();
     });
     assertEquals(VERTX_DEPLOYMENT, exitCode);
-    assertTrue(out.toString().contains("Usage:"));
+    assertFalse(out.toString().contains("Usage:"));
     assertTrue(err.toString().contains("ClassNotFoundException"));
   }
 


### PR DESCRIPTION
Fixes #12

In VertxApplication, we must inspect the exit code. If the exit code equals 2 (Picocli's default for usage), then usage must be displayed (unless disabled by the user).