### PR TITLE
Don't invoke System.exit in case of success

### DIFF
--- a/application/src/main/java/io/vertx/launcher/application/VertxApplication.java
+++ b/application/src/main/java/io/vertx/launcher/application/VertxApplication.java
@@ -102,7 +102,7 @@ public class VertxApplication {
     if (exitCode == ExitCodes.USAGE && printUsageOnFailure) {
       CommandLine.usage(command, System.out, Ansi.ON);
     }
-    if (exitOnFailure) {
+    if (exitCode != 0 && exitOnFailure) {
       System.exit(exitCode);
     }
     return exitCode;


### PR DESCRIPTION
Follows-up on #15

Otherwise, the method can never return normally.