### PR TITLE
Deployable support in VertxApplicationHooks#verticleSupplier

### DIFF
--- a/application/src/main/java/io/vertx/launcher/application/VertxApplicationHooks.java
+++ b/application/src/main/java/io/vertx/launcher/application/VertxApplicationHooks.java
@@ -11,7 +11,7 @@
 
 package io.vertx.launcher.application;
 
-import io.vertx.core.Verticle;
+import io.vertx.core.Deployable;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxBuilder;
 import io.vertx.core.VertxOptions;
@@ -67,12 +67,12 @@ public interface VertxApplicationHooks {
   }
 
   /**
-   * Invoked before deploying the main verticle.
+   * Invoked before deploying the main verticle or {@link Deployable}.
    * <p>
    * If the implementation returns a non-{@code null} supplier, it will be used to create the instance(s) of the verticle,
    * regardless of the value provided on the command line or in the JAR's {@code META-INF/MANIFEST.MF} file.
    */
-  default Supplier<Verticle> verticleSupplier() {
+  default Supplier<Deployable> verticleSupplier() {
     return null;
   }
 

--- a/application/src/main/java/io/vertx/launcher/application/impl/VertxApplicationCommand.java
+++ b/application/src/main/java/io/vertx/launcher/application/impl/VertxApplicationCommand.java
@@ -213,7 +213,7 @@ public class VertxApplicationCommand implements Runnable {
     DeploymentOptions deploymentOptions = createDeploymentOptions();
 
     Supplier<Future<String>> deployer;
-    Supplier<Verticle> verticleSupplier = hooks.verticleSupplier();
+    Supplier<Deployable> verticleSupplier = hooks.verticleSupplier();
     if (verticleSupplier == null) {
       String verticleName = computeVerticleName(vertxApplication.getClass(), mainVerticle);
       if (verticleName == null) {

--- a/application/src/test/java/io/vertx/launcher/application/tests/HttpTestDeployable.java
+++ b/application/src/test/java/io/vertx/launcher/application/tests/HttpTestDeployable.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.launcher.application.tests;
+
+import io.vertx.core.Context;
+import io.vertx.core.Deployable;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+public class HttpTestDeployable implements Deployable {
+  @Override
+  public Future<?> deploy(Context context) throws Exception {
+    long time = System.nanoTime();
+    Vertx vertx = context.owner();
+    return vertx.createHttpServer().requestHandler(request -> {
+      JsonObject json = new JsonObject();
+      json
+        .put("threadingModel", context.threadingModel())
+        .put("clustered", vertx.isClustered())
+        .put("metrics", vertx.isMetricsEnabled())
+        .put("id", System.getProperty("vertx.id", "no id"))
+        .put("conf", context.config())
+        .put("startTime", time);
+
+      if (System.getProperty("foo") != null) {
+        json.put("foo", System.getProperty("foo"));
+      }
+
+      if (System.getProperty("baz") != null) {
+        json.put("baz", System.getProperty("baz"));
+      }
+
+      request.response().putHeader("content-type", "application/json").end(json.encodePrettily());
+    }).listen(8080);
+  }
+}

--- a/application/src/test/java/io/vertx/launcher/application/tests/VertxApplicationExtensibilityTest.java
+++ b/application/src/test/java/io/vertx/launcher/application/tests/VertxApplicationExtensibilityTest.java
@@ -11,7 +11,7 @@
 
 package io.vertx.launcher.application.tests;
 
-import io.vertx.core.Verticle;
+import io.vertx.core.Deployable;
 import io.vertx.core.VertxBuilder;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.internal.VertxInternal;
@@ -47,8 +47,21 @@ public class VertxApplicationExtensibilityTest {
   public void testExtendingMainVerticle() {
     hooks = new TestHooks() {
       @Override
-      public Supplier<Verticle> verticleSupplier() {
+      public Supplier<Deployable> verticleSupplier() {
         return () -> new HttpTestVerticle();
+      }
+    };
+    TestVertxApplication app = new TestVertxApplication(new String[0], hooks);
+    app.launch();
+    assertServerStarted();
+  }
+
+  @Test
+  public void testExtendingMainVerticleWithDeployable() {
+    hooks = new TestHooks() {
+      @Override
+      public Supplier<Deployable> verticleSupplier() {
+        return () -> new HttpTestDeployable();
       }
     };
     TestVertxApplication app = new TestVertxApplication(new String[0], hooks);
@@ -61,7 +74,7 @@ public class VertxApplicationExtensibilityTest {
     long time = System.nanoTime();
     hooks = new TestHooks() {
       @Override
-      public Supplier<Verticle> verticleSupplier() {
+      public Supplier<Deployable> verticleSupplier() {
         return () -> new HttpTestVerticle();
       }
 
@@ -81,7 +94,7 @@ public class VertxApplicationExtensibilityTest {
     long time = System.nanoTime();
     hooks = new TestHooks() {
       @Override
-      public Supplier<Verticle> verticleSupplier() {
+      public Supplier<Deployable> verticleSupplier() {
         return () -> new HttpTestVerticle();
       }
 
@@ -100,7 +113,7 @@ public class VertxApplicationExtensibilityTest {
   public void testThatCustomLauncherCanCustomizeMetricsOption() throws Exception {
     hooks = new TestHooks() {
       @Override
-      public Supplier<Verticle> verticleSupplier() {
+      public Supplier<Deployable> verticleSupplier() {
         return () -> new HttpTestVerticle();
       }
 
@@ -127,7 +140,7 @@ public class VertxApplicationExtensibilityTest {
     FakeClusterManager clusterManager = new FakeClusterManager();
     hooks = new TestHooks() {
       @Override
-      public Supplier<Verticle> verticleSupplier() {
+      public Supplier<Deployable> verticleSupplier() {
         return () -> new HttpTestVerticle();
       }
 


### PR DESCRIPTION
In a Vert.x application, users can set the main verticle using the `verticleSupplier` hook.

Previously, the return supplier parameter type was `Verticle`, making it impossible to set a verticle extending `VerticleBase` (or a bare `Deployable`).