### PR TITLE
Relax verticle supplier contract

### DIFF
--- a/application/src/main/java/io/vertx/launcher/application/VertxApplicationHooks.java
+++ b/application/src/main/java/io/vertx/launcher/application/VertxApplicationHooks.java
@@ -72,7 +72,7 @@ public interface VertxApplicationHooks {
    * If the implementation returns a non-{@code null} supplier, it will be used to create the instance(s) of the verticle,
    * regardless of the value provided on the command line or in the JAR's {@code META-INF/MANIFEST.MF} file.
    */
-  default Supplier<Deployable> verticleSupplier() {
+  default Supplier<? extends Deployable> verticleSupplier() {
     return null;
   }
 

--- a/application/src/main/java/io/vertx/launcher/application/impl/VertxApplicationCommand.java
+++ b/application/src/main/java/io/vertx/launcher/application/impl/VertxApplicationCommand.java
@@ -213,7 +213,7 @@ public class VertxApplicationCommand implements Runnable {
     DeploymentOptions deploymentOptions = createDeploymentOptions();
 
     Supplier<Future<String>> deployer;
-    Supplier<Deployable> verticleSupplier = hooks.verticleSupplier();
+    Supplier<? extends Deployable> verticleSupplier = hooks.verticleSupplier();
     if (verticleSupplier == null) {
       String verticleName = computeVerticleName(vertxApplication.getClass(), mainVerticle);
       if (verticleName == null) {

--- a/application/src/test/java/io/vertx/launcher/application/tests/VertxApplicationExtensibilityTest.java
+++ b/application/src/test/java/io/vertx/launcher/application/tests/VertxApplicationExtensibilityTest.java
@@ -12,6 +12,7 @@
 package io.vertx.launcher.application.tests;
 
 import io.vertx.core.Deployable;
+import io.vertx.core.Verticle;
 import io.vertx.core.VertxBuilder;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.internal.VertxInternal;
@@ -47,7 +48,7 @@ public class VertxApplicationExtensibilityTest {
   public void testExtendingMainVerticle() {
     hooks = new TestHooks() {
       @Override
-      public Supplier<Deployable> verticleSupplier() {
+      public Supplier<Verticle> verticleSupplier() {
         return () -> new HttpTestVerticle();
       }
     };
@@ -74,7 +75,7 @@ public class VertxApplicationExtensibilityTest {
     long time = System.nanoTime();
     hooks = new TestHooks() {
       @Override
-      public Supplier<Deployable> verticleSupplier() {
+      public Supplier<Verticle> verticleSupplier() {
         return () -> new HttpTestVerticle();
       }
 
@@ -94,7 +95,7 @@ public class VertxApplicationExtensibilityTest {
     long time = System.nanoTime();
     hooks = new TestHooks() {
       @Override
-      public Supplier<Deployable> verticleSupplier() {
+      public Supplier<Verticle> verticleSupplier() {
         return () -> new HttpTestVerticle();
       }
 
@@ -113,7 +114,7 @@ public class VertxApplicationExtensibilityTest {
   public void testThatCustomLauncherCanCustomizeMetricsOption() throws Exception {
     hooks = new TestHooks() {
       @Override
-      public Supplier<Deployable> verticleSupplier() {
+      public Supplier<Verticle> verticleSupplier() {
         return () -> new HttpTestVerticle();
       }
 
@@ -140,7 +141,7 @@ public class VertxApplicationExtensibilityTest {
     FakeClusterManager clusterManager = new FakeClusterManager();
     hooks = new TestHooks() {
       @Override
-      public Supplier<Deployable> verticleSupplier() {
+      public Supplier<Verticle> verticleSupplier() {
         return () -> new HttpTestVerticle();
       }
 


### PR DESCRIPTION
Follows-up on #22

Relaxing the verticle supplier contract allows the user to declare a method returning a `Supplier<Verticle>` or `Supplier<MyVerticle>`.