### PR TITLE
Run CI on Windows 2022

### DIFF
--- a/.github/workflows/ci-5.x.yml
+++ b/.github/workflows/ci-5.x.yml
@@ -19,7 +19,7 @@ jobs:
           - os: ubuntu-latest
             jdk: 21
             profile: ''
-          - os: windows-latest
+          - os: windows-2022
             jdk: 11
             profile: ''
     uses: ./.github/workflows/ci.yml


### PR DESCRIPTION
Build fails with Windows 2025 and we can't reproduce with Windows 11