### PR TITLE
Fix test ServiceCommandLoaderTest.testNoCommandsWhenLoadedFromEmptyClassloader

### DIFF
--- a/cli/src/test/java/io/vertx/core/impl/launcher/ServiceCommandLoaderTest.java
+++ b/cli/src/test/java/io/vertx/core/impl/launcher/ServiceCommandLoaderTest.java
@@ -55,7 +55,7 @@ public class ServiceCommandLoaderTest {
 
     // We see the implementation from the classpath
     loader = new ServiceCommandFactoryLoader(classLoader);
-    assertThat(loader.lookup()).isNotEmpty();
+    assertThat(loader.lookup()).isEmpty();
   }
 
 


### PR DESCRIPTION
Follows-up on https://github.com/eclipse-vertx/vert.x/pull/5948