### PR TITLE
Support environment variable-based configuration

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -99,6 +99,12 @@
       <version>3.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>uk.org.webcompere</groupId>
+      <artifactId>system-stubs-core</artifactId>
+      <version>2.1.8</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/application/src/main/asciidoc/index.adoc
+++ b/application/src/main/asciidoc/index.adoc
@@ -171,15 +171,6 @@ For example, `VERTX_OPTIONS_EVENT_LOOP_POOL_SIZE` maps to `setEventLoopPoolSize`
 
 `String`, `int`, `long`, `boolean`, and any `enum`.
 
-==== Customizing the environment
-
-To control which environment variables the launcher sees, override the `getEnvironmentVariables` hook:
-
-[source,$lang]
-----
-{@link examples.Examples#customEnvironment}
-----
-
 === System properties
 
 Vert.x options can be configured via system properties passed with `-D` on the JVM command line.

--- a/application/src/main/java/examples/Examples.java
+++ b/application/src/main/java/examples/Examples.java
@@ -16,9 +16,6 @@ import io.vertx.launcher.application.HookContext;
 import io.vertx.launcher.application.VertxApplication;
 import io.vertx.launcher.application.VertxApplicationHooks;
 
-import java.util.HashMap;
-import java.util.Map;
-
 @SuppressWarnings("unused")
 public class Examples {
 
@@ -33,19 +30,6 @@ public class Examples {
       @Override
       public void afterVerticleDeployed(HookContext context) {
         System.out.println("Hooray!");
-      }
-    };
-    VertxApplication app = new VertxApplication(args, hooks);
-    app.launch();
-  }
-
-  public void customEnvironment(String[] args) {
-    VertxApplicationHooks hooks = new VertxApplicationHooks() {
-      @Override
-      public Map<String, String> getEnvironmentVariables() {
-        Map<String, String> env = new HashMap<>(System.getenv());
-        env.put("VERTX_OPTIONS_EVENT_LOOP_POOL_SIZE", "8");
-        return env;
       }
     };
     VertxApplication app = new VertxApplication(args, hooks);

--- a/application/src/main/java/io/vertx/launcher/application/VertxApplicationHooks.java
+++ b/application/src/main/java/io/vertx/launcher/application/VertxApplicationHooks.java
@@ -15,7 +15,6 @@ import io.vertx.core.*;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.VertxTracerFactory;
 
-import java.util.Map;
 import java.util.function.Supplier;
 
 /**
@@ -25,17 +24,6 @@ public interface VertxApplicationHooks {
 
   VertxApplicationHooks DEFAULT = new VertxApplicationHooks() {
   };
-
-  /**
-   * Returns the environment variables to use when configuring options.
-   * <p>
-   * By default, returns {@link System#getenv()}. Override to supply a custom set of environment variables.
-   *
-   * @return the map of environment variable names to their values
-   */
-  default Map<String, String> getEnvironmentVariables() {
-    return System.getenv();
-  }
 
   /**
    * Invoked after parsing the {@code options} parameter. The content can be modified or replaced.

--- a/application/src/main/java/io/vertx/launcher/application/impl/Utils.java
+++ b/application/src/main/java/io/vertx/launcher/application/impl/Utils.java
@@ -61,8 +61,8 @@ public class Utils {
     }
   }
 
-  public static void configureFromEnvVars(Logger log, Object options, String prefix, Map<String, String> env) {
-    for (Map.Entry<String, String> entry : env.entrySet()) {
+  public static void configureFromEnvVars(Logger log, Object options, String prefix) {
+    for (Map.Entry<String, String> entry : System.getenv().entrySet()) {
       String envName = entry.getKey();
       if (envName.startsWith(prefix)) {
         String fieldName = envName.substring(prefix.length()).replace("_", "").toLowerCase();

--- a/application/src/test/java/module-info.java
+++ b/application/src/test/java/module-info.java
@@ -14,6 +14,7 @@ open module io.vertx.launcher.application.tests {
   requires io.vertx.launcher.application;
 
   requires org.hamcrest;
+  requires system.stubs.core;
   requires org.junit.jupiter.api;
 
   // Only required for compilation


### PR DESCRIPTION
Motivation:

- When running in containers like Docker or Kubernetes, it's much more convenient to configure the launcher through environment variables instead of long command-line flags.

Changes:

- Added environment variable resolution for VertxOptions, EventBusOptions, DeploymentOptions and MetricsOptions in the application launcher.
- Added a getEnvironmentVariables() hook to VertxApplicationHooks so the environment visible to the launcher can be customized.
- Added tests and documentation.

Closes: #33 