### PR TITLE
Add ConfigLoader SPI for pluggable configuration sources

### DIFF
--- a/application/src/main/asciidoc/index.adoc
+++ b/application/src/main/asciidoc/index.adoc
@@ -209,13 +209,45 @@ For example, `-Dvertx.options.eventLoopPoolSize=8` maps to `setEventLoopPoolSize
 Options are applied in this order, where later entries win:
 
 1. JSON options (via `-options` / `-deployment-options`)
-2. Environment variables
-3. CLI arguments (e.g. `--cluster-host`, `--instances`, `--worker`)
-4. System properties (via `-D`)
+2. {@link io.vertx.launcher.application.ConfigLoader} chain, sorted by {@link io.vertx.launcher.application.ConfigLoader#order()}:
+  - Environment variables (order 1000)
+  - Custom config loaders (any order)
+  - System properties (order 2000)
+3. CLI arguments (e.g. `--cluster-host`, `--instances`, `--worker`) — always win
 
-For example, if `VERTX_OPTIONS_EVENT_LOOP_POOL_SIZE=5` is set but `-Dvertx.options.eventLoopPoolSize=10` is also passed, the event loop pool size will be `10`.
+For example, if `VERTX_OPTIONS_EVENT_LOOP_POOL_SIZE=5` is set but `-Dvertx.options.eventLoopPoolSize=10` is also passed, the event loop pool size will be `10` because system properties have a higher order than environment variables.
+
+CLI arguments always take precedence. For instance, `--instances 3` will override any value set by environment variables, system properties, or custom config loaders.
 
 == Extensibility
+
+=== Custom config loaders
+
+The launcher supports a {@link io.vertx.launcher.application.ConfigLoader} SPI for plugging in custom configuration sources (e.g. AWS AppConfig, Firebase Remote Config, a configuration file, etc.).
+
+Implementations are discovered via `java.util.ServiceLoader` and applied in {@link io.vertx.launcher.application.ConfigLoader#order()} sequence.
+A lower order means the loader runs first (and has lower precedence); a higher order means it runs later (and wins over lower-order loaders).
+
+The {@link io.vertx.launcher.application.ConfigScope} parameter tells the loader which options type is being configured, allowing scope-specific logic.
+
+[source,$lang]
+.Custom config loader implementation
+----
+{@link examples.Examples#customConfigLoader}
+----
+
+To register the implementation, add a `META-INF/services/io.vertx.launcher.application.ConfigLoader` file to your classpath:
+
+----
+com.example.AppConfigLoader
+----
+
+Or, if using the Java module system, add to your `module-info.java`:
+
+[source,java]
+----
+provides io.vertx.launcher.application.ConfigLoader with com.example.AppConfigLoader;
+----
 
 === Hooks
 

--- a/application/src/main/java/examples/Examples.java
+++ b/application/src/main/java/examples/Examples.java
@@ -12,12 +12,34 @@
 package examples;
 
 import io.vertx.core.VertxOptions;
+import io.vertx.launcher.application.ConfigLoader;
+import io.vertx.launcher.application.ConfigScope;
 import io.vertx.launcher.application.HookContext;
 import io.vertx.launcher.application.VertxApplication;
 import io.vertx.launcher.application.VertxApplicationHooks;
 
 @SuppressWarnings("unused")
 public class Examples {
+
+  public void customConfigLoader() {
+    class AppConfigLoader implements ConfigLoader {
+
+      @Override
+      public int order() {
+        // Between environment variables (1000) and system properties (2000)
+        return 1500;
+      }
+
+      @Override
+      public void configure(Object target, ConfigScope scope) {
+        if (scope == ConfigScope.VERTX && target instanceof VertxOptions) {
+          VertxOptions options = (VertxOptions) target;
+          // Load from your custom source (e.g. AWS AppConfig, Firebase Remote Config, a file, etc.)
+          options.setEventLoopPoolSize(4);
+        }
+      }
+    }
+  }
 
   public void hooks(String[] args) {
     VertxApplicationHooks hooks = new VertxApplicationHooks() {

--- a/application/src/main/java/io/vertx/launcher/application/ConfigLoader.java
+++ b/application/src/main/java/io/vertx/launcher/application/ConfigLoader.java
@@ -1,0 +1,41 @@
+package io.vertx.launcher.application;
+
+/**
+ * SPI for plugging custom configuration sources into the {@link io.vertx.launcher.application.VertxApplication} launch process.
+ * <p>
+ * Implementations are discovered via {@link java.util.ServiceLoader} and applied in {@link #order()} sequence
+ * to each options object (e.g. {@link io.vertx.core.VertxOptions}, {@link io.vertx.core.DeploymentOptions}).
+ * <p>
+ * The default implementations load configuration from environment variables (order 1000) and
+ * system properties (order 2000). CLI flags always take precedence over all config loaders.
+ *
+ * <h3>Precedence (lowest to highest)</h3>
+ * <ol>
+ *   <li>JSON file/string ({@code --options}, {@code --deployment-options})</li>
+ *   <li>Config loaders sorted by {@link #order()} (lower = applied first, higher = applied later and wins)</li>
+ *   <li>CLI flags ({@code --worker}, {@code --instances}, {@code --cluster-host}, etc.)</li>
+ * </ol>
+ */
+public interface ConfigLoader {
+
+  /**
+   * Returns the order of this loader. Loaders are applied from lowest to highest order,
+   * so a higher-order loader's values override those set by a lower-order loader.
+   * <p>
+   * Default loaders use: environment variables = 1000, system properties = 2000.
+   *
+   * @return the order value
+   */
+  int order();
+
+  /**
+   * Applies configuration to the given target options object.
+   *
+   * @param target the options object to configure (e.g. {@link io.vertx.core.VertxOptions},
+   *               {@link io.vertx.core.eventbus.EventBusOptions}, {@link io.vertx.core.DeploymentOptions},
+   *               or {@link io.vertx.core.metrics.MetricsOptions})
+   * @param scope  identifies which configuration scope is being applied
+   */
+  void configure(Object target, ConfigScope scope);
+
+}

--- a/application/src/main/java/io/vertx/launcher/application/ConfigScope.java
+++ b/application/src/main/java/io/vertx/launcher/application/ConfigScope.java
@@ -1,0 +1,29 @@
+package io.vertx.launcher.application;
+
+/**
+ * Identifies the configuration scope being applied by a {@link ConfigLoader}.
+ * <p>
+ * Each scope corresponds to a specific Vert.x options type.
+ */
+public enum ConfigScope {
+
+  /**
+   * Vert.x core options ({@link io.vertx.core.VertxOptions}).
+   */
+  VERTX,
+
+  /**
+   * Event bus options ({@link io.vertx.core.eventbus.EventBusOptions}), applied when clustering is enabled.
+   */
+  EVENTBUS,
+
+  /**
+   * Deployment options ({@link io.vertx.core.DeploymentOptions}) for the main verticle.
+   */
+  DEPLOYMENT,
+
+  /**
+   * Metrics options ({@link io.vertx.core.metrics.MetricsOptions}), applied when a metrics factory is present.
+   */
+  METRICS
+}

--- a/application/src/main/java/io/vertx/launcher/application/impl/AbstractConfigLoader.java
+++ b/application/src/main/java/io/vertx/launcher/application/impl/AbstractConfigLoader.java
@@ -1,0 +1,68 @@
+package io.vertx.launcher.application.impl;
+
+import io.vertx.core.VertxException;
+import io.vertx.core.internal.logging.Logger;
+import io.vertx.core.internal.logging.LoggerFactory;
+import io.vertx.launcher.application.ConfigLoader;
+
+import java.lang.reflect.Method;
+
+public abstract class AbstractConfigLoader implements ConfigLoader {
+
+  protected final Logger log = LoggerFactory.getLogger(getClass());
+
+  protected void configureOption(Object options, String fieldName, String value) {
+    Method setter = getSetter(fieldName, options.getClass());
+    if (setter == null) {
+      log.warn("No such property to configure on options: " + options.getClass().getName() + "." + fieldName);
+      return;
+    }
+    Class<?> argType = setter.getParameterTypes()[0];
+    Object arg;
+    try {
+      if (argType.equals(String.class)) {
+        arg = value;
+      } else if (argType.equals(int.class)) {
+        arg = Integer.valueOf(value);
+      } else if (argType.equals(long.class)) {
+        arg = Long.valueOf(value);
+      } else if (argType.equals(boolean.class)) {
+        arg = Boolean.valueOf(value);
+      } else if (argType.isEnum()) {
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        Object enumVal = Enum.valueOf((Class<? extends Enum>) argType, value);
+        arg = enumVal;
+      } else {
+        log.warn("Invalid type for setter: " + argType);
+        return;
+      }
+    } catch (IllegalArgumentException e) {
+      log.warn("Invalid argtype:" + argType + " on options: " + options.getClass().getName() + "." + fieldName);
+      return;
+    }
+    try {
+      setter.invoke(options, arg);
+    } catch (Exception ex) {
+      throw new VertxException("Failed to invoke setter: " + setter, ex);
+    }
+  }
+
+  private static Method getSetter(String fieldName, Class<?> clazz) {
+    Method[] meths = clazz.getDeclaredMethods();
+    for (Method meth : meths) {
+      if (("set" + fieldName).equalsIgnoreCase(meth.getName())) {
+        return meth;
+      }
+    }
+
+    // This set contains the overridden methods
+    meths = clazz.getMethods();
+    for (Method meth : meths) {
+      if (("set" + fieldName).equalsIgnoreCase(meth.getName())) {
+        return meth;
+      }
+    }
+
+    return null;
+  }
+}

--- a/application/src/main/java/io/vertx/launcher/application/impl/CompositeConfigLoader.java
+++ b/application/src/main/java/io/vertx/launcher/application/impl/CompositeConfigLoader.java
@@ -1,0 +1,29 @@
+package io.vertx.launcher.application.impl;
+
+import io.vertx.launcher.application.ConfigLoader;
+import io.vertx.launcher.application.ConfigScope;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+
+public class CompositeConfigLoader {
+
+  private final List<ConfigLoader> loaders;
+
+  public CompositeConfigLoader() {
+    List<ConfigLoader> list = new ArrayList<>();
+    for (ConfigLoader loader : ServiceLoader.load(ConfigLoader.class, Thread.currentThread().getContextClassLoader())) {
+      list.add(loader);
+    }
+    list.sort(Comparator.comparingInt(ConfigLoader::order));
+    this.loaders = List.copyOf(list);
+  }
+
+  public void apply(Object target, ConfigScope scope) {
+    for (ConfigLoader loader : loaders) {
+      loader.configure(target, scope);
+    }
+  }
+}

--- a/application/src/main/java/io/vertx/launcher/application/impl/EnvironmentVariableConfigLoader.java
+++ b/application/src/main/java/io/vertx/launcher/application/impl/EnvironmentVariableConfigLoader.java
@@ -1,0 +1,36 @@
+package io.vertx.launcher.application.impl;
+
+import io.vertx.launcher.application.ConfigScope;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+public class EnvironmentVariableConfigLoader extends AbstractConfigLoader {
+
+  private static final EnumMap<ConfigScope, String> PREFIXES = new EnumMap<>(Map.of(
+    ConfigScope.VERTX, "VERTX_OPTIONS_",
+    ConfigScope.EVENTBUS, "VERTX_EVENTBUS_OPTIONS_",
+    ConfigScope.DEPLOYMENT, "VERTX_DEPLOYMENT_OPTIONS_",
+    ConfigScope.METRICS, "VERTX_METRICS_OPTIONS_"
+  ));
+
+  @Override
+  public int order() {
+    return 1000;
+  }
+
+  @Override
+  public void configure(Object target, ConfigScope scope) {
+    String prefix = PREFIXES.get(scope);
+    if (prefix == null) {
+      return;
+    }
+    for (Map.Entry<String, String> entry : System.getenv().entrySet()) {
+      String envName = entry.getKey();
+      if (envName.startsWith(prefix)) {
+        String fieldName = envName.substring(prefix.length()).replace("_", "").toLowerCase();
+        configureOption(target, fieldName, entry.getValue());
+      }
+    }
+  }
+}

--- a/application/src/main/java/io/vertx/launcher/application/impl/SystemPropertyConfigLoader.java
+++ b/application/src/main/java/io/vertx/launcher/application/impl/SystemPropertyConfigLoader.java
@@ -1,0 +1,40 @@
+package io.vertx.launcher.application.impl;
+
+import io.vertx.launcher.application.ConfigScope;
+
+import java.util.EnumMap;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Properties;
+
+public class SystemPropertyConfigLoader extends AbstractConfigLoader {
+
+  private static final EnumMap<ConfigScope, String> PREFIXES = new EnumMap<>(Map.of(
+    ConfigScope.VERTX, "vertx.options.",
+    ConfigScope.EVENTBUS, "vertx.eventBus.options.",
+    ConfigScope.DEPLOYMENT, "vertx.deployment.options.",
+    ConfigScope.METRICS, "vertx.metrics.options."
+  ));
+
+  @Override
+  public int order() {
+    return 2000;
+  }
+
+  @Override
+  public void configure(Object target, ConfigScope scope) {
+    String prefix = PREFIXES.get(scope);
+    if (prefix == null) {
+      return;
+    }
+    Properties props = System.getProperties();
+    Enumeration<?> e = props.propertyNames();
+    while (e.hasMoreElements()) {
+      String propName = (String) e.nextElement();
+      if (propName.startsWith(prefix)) {
+        String fieldName = propName.substring(prefix.length());
+        configureOption(target, fieldName, props.getProperty(propName));
+      }
+    }
+  }
+}

--- a/application/src/main/java/io/vertx/launcher/application/impl/Utils.java
+++ b/application/src/main/java/io/vertx/launcher/application/impl/Utils.java
@@ -11,7 +11,6 @@
 
 package io.vertx.launcher.application.impl;
 
-import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.json.DecodeException;
@@ -19,7 +18,6 @@ import io.vertx.core.json.JsonObject;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Method;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -46,81 +44,6 @@ public class Utils {
     } catch (DecodeException ignored) {
     }
     log.warn("The " + optionName + " option does not point to an valid JSON file or is not a valid JSON object.");
-    return null;
-  }
-
-  public static void configureFromSystemProperties(Logger log, Object options, String prefix) {
-    Properties props = System.getProperties();
-    Enumeration<?> e = props.propertyNames();
-    while (e.hasMoreElements()) {
-      String propName = (String) e.nextElement();
-      if (propName.startsWith(prefix)) {
-        String fieldName = propName.substring(prefix.length());
-        configureOption(log, options, fieldName, props.getProperty(propName));
-      }
-    }
-  }
-
-  public static void configureFromEnvVars(Logger log, Object options, String prefix) {
-    for (Map.Entry<String, String> entry : System.getenv().entrySet()) {
-      String envName = entry.getKey();
-      if (envName.startsWith(prefix)) {
-        String fieldName = envName.substring(prefix.length()).replace("_", "").toLowerCase();
-        configureOption(log, options, fieldName, entry.getValue());
-      }
-    }
-  }
-
-  private static void configureOption(Logger log, Object options, String fieldName, String value) {
-    Method setter = getSetter(fieldName, options.getClass());
-    if (setter == null) {
-      log.warn("No such property to configure on options: " + options.getClass().getName() + "." + fieldName);
-      return;
-    }
-    Class<?> argType = setter.getParameterTypes()[0];
-    Object arg;
-    try {
-      if (argType.equals(String.class)) {
-        arg = value;
-      } else if (argType.equals(int.class)) {
-        arg = Integer.valueOf(value);
-      } else if (argType.equals(long.class)) {
-        arg = Long.valueOf(value);
-      } else if (argType.equals(boolean.class)) {
-        arg = Boolean.valueOf(value);
-      } else if (argType.isEnum()) {
-        arg = Enum.valueOf((Class<? extends Enum>) argType, value);
-      } else {
-        log.warn("Invalid type for setter: " + argType);
-        return;
-      }
-    } catch (IllegalArgumentException e) {
-      log.warn("Invalid argtype:" + argType + " on options: " + options.getClass().getName() + "." + fieldName);
-      return;
-    }
-    try {
-      setter.invoke(options, arg);
-    } catch (Exception ex) {
-      throw new VertxException("Failed to invoke setter: " + setter, ex);
-    }
-  }
-
-  private static Method getSetter(String fieldName, Class<?> clazz) {
-    Method[] meths = clazz.getDeclaredMethods();
-    for (Method meth : meths) {
-      if (("set" + fieldName).equalsIgnoreCase(meth.getName())) {
-        return meth;
-      }
-    }
-
-    // This set contains the overridden methods
-    meths = clazz.getMethods();
-    for (Method meth : meths) {
-      if (("set" + fieldName).equalsIgnoreCase(meth.getName())) {
-        return meth;
-      }
-    }
-
     return null;
   }
 

--- a/application/src/main/java/io/vertx/launcher/application/impl/VertxApplicationCommand.java
+++ b/application/src/main/java/io/vertx/launcher/application/impl/VertxApplicationCommand.java
@@ -21,6 +21,7 @@ import io.vertx.core.spi.VertxMetricsFactory;
 import io.vertx.core.spi.VertxServiceProvider;
 import io.vertx.core.spi.VertxTracerFactory;
 import io.vertx.core.tracing.TracingOptions;
+import io.vertx.launcher.application.ConfigScope;
 import io.vertx.launcher.application.ExitCodes;
 import io.vertx.launcher.application.VertxApplication;
 import io.vertx.launcher.application.VertxApplicationHooks;
@@ -37,23 +38,14 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
-import static io.vertx.launcher.application.impl.Utils.*;
+import static io.vertx.launcher.application.impl.Utils.computeVerticleName;
+import static io.vertx.launcher.application.impl.Utils.readJsonFileOrString;
 import static java.lang.Boolean.TRUE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static picocli.CommandLine.Parameters.NULL_VALUE;
 
 @Command(name = "VertxApplication", description = "Runs a Vert.x application.", sortOptions = false)
 public class VertxApplicationCommand implements Runnable {
-
-  private static final String VERTX_OPTIONS_PROP_PREFIX = "vertx.options.";
-  private static final String VERTX_EVENTBUS_PROP_PREFIX = "vertx.eventBus.options.";
-  private static final String DEPLOYMENT_OPTIONS_PROP_PREFIX = "vertx.deployment.options.";
-  private static final String METRICS_OPTIONS_PROP_PREFIX = "vertx.metrics.options.";
-
-  static final String VERTX_OPTIONS_ENV_PREFIX = "VERTX_OPTIONS_";
-  static final String VERTX_EVENTBUS_OPTIONS_ENV_PREFIX = "VERTX_EVENTBUS_OPTIONS_";
-  static final String DEPLOYMENT_OPTIONS_ENV_PREFIX = "VERTX_DEPLOYMENT_OPTIONS_";
-  static final String METRICS_OPTIONS_ENV_PREFIX = "VERTX_METRICS_OPTIONS_";
 
   @Option(
     names = {"-options", "--options", "-vertx-options", "--vertx-options"},
@@ -184,6 +176,7 @@ public class VertxApplicationCommand implements Runnable {
   private final VertxApplication vertxApplication;
   private final VertxApplicationHooks hooks;
   private final Logger log;
+  private final CompositeConfigLoader configLoader = new CompositeConfigLoader();
   private final HookContextImpl hookContext = new HookContextImpl();
 
   private volatile VertxInternal vertx;
@@ -246,7 +239,7 @@ public class VertxApplicationCommand implements Runnable {
   private void processVertxOptions(VertxOptions vertxOptions, JsonObject optionsJson) {
     if (clustered == TRUE) {
       EventBusOptions eventBusOptions = vertxOptions.getEventBusOptions();
-      configureFromEnvVars(log, eventBusOptions, VERTX_EVENTBUS_OPTIONS_ENV_PREFIX);
+      configLoader.apply(eventBusOptions, ConfigScope.EVENTBUS);
       if (clusterHost != null) {
         eventBusOptions.setHost(clusterHost);
       }
@@ -259,10 +252,8 @@ public class VertxApplicationCommand implements Runnable {
       if (clusterPublicPort != null) {
         eventBusOptions.setClusterPublicPort(clusterPublicPort);
       }
-      configureFromSystemProperties(log, eventBusOptions, VERTX_EVENTBUS_PROP_PREFIX);
     }
-    configureFromEnvVars(log, vertxOptions, VERTX_OPTIONS_ENV_PREFIX);
-    configureFromSystemProperties(log, vertxOptions, VERTX_OPTIONS_PROP_PREFIX);
+    configLoader.apply(vertxOptions, ConfigScope.VERTX);
     VertxMetricsFactory metricsFactory = findServiceProvider(VertxMetricsFactory.class);
     if (metricsFactory != null) {
       MetricsOptions metricsOptions;
@@ -276,8 +267,7 @@ public class VertxApplicationCommand implements Runnable {
           metricsOptions = metricsFactory.newOptions(metricsOptions);
         }
       }
-      configureFromEnvVars(log, metricsOptions, METRICS_OPTIONS_ENV_PREFIX);
-      configureFromSystemProperties(log, metricsOptions, METRICS_OPTIONS_PROP_PREFIX);
+      configLoader.apply(metricsOptions, ConfigScope.METRICS);
       vertxOptions.setMetricsOptions(metricsOptions);
     }
     VertxTracerFactory tracerFactory = findServiceProvider(VertxTracerFactory.class);
@@ -308,7 +298,7 @@ public class VertxApplicationCommand implements Runnable {
 
   private DeploymentOptions createDeploymentOptions(JsonObject deploymentOptionsParam, JsonObject confParam) {
     DeploymentOptions deploymentOptions = deploymentOptionsParam != null ? new DeploymentOptions(deploymentOptionsParam) : new DeploymentOptions();
-    configureFromEnvVars(log, deploymentOptions, DEPLOYMENT_OPTIONS_ENV_PREFIX);
+    configLoader.apply(deploymentOptions, ConfigScope.DEPLOYMENT);
     if (worker == TRUE) {
       if (virtualThread == TRUE) {
         log.error("Cannot choose the threading model, the virtual thread and worker options are both set.");
@@ -326,7 +316,6 @@ public class VertxApplicationCommand implements Runnable {
     } else {
       deploymentOptions.setConfig(new JsonObject());
     }
-    configureFromSystemProperties(log, deploymentOptions, DEPLOYMENT_OPTIONS_PROP_PREFIX);
     return deploymentOptions;
   }
 

--- a/application/src/main/java/module-info.java
+++ b/application/src/main/java/module-info.java
@@ -18,7 +18,12 @@ module io.vertx.launcher.application {
   requires static io.vertx.docgen;
 
   uses io.vertx.core.spi.VertxServiceProvider;
+  uses io.vertx.launcher.application.ConfigLoader;
   opens io.vertx.launcher.application.impl to info.picocli;
 
   exports io.vertx.launcher.application;
+
+  provides io.vertx.launcher.application.ConfigLoader with
+    io.vertx.launcher.application.impl.EnvironmentVariableConfigLoader,
+    io.vertx.launcher.application.impl.SystemPropertyConfigLoader;
 }

--- a/application/src/main/resources/META-INF/services/io.vertx.launcher.application.ConfigLoader
+++ b/application/src/main/resources/META-INF/services/io.vertx.launcher.application.ConfigLoader
@@ -1,0 +1,2 @@
+io.vertx.launcher.application.impl.EnvironmentVariableConfigLoader
+io.vertx.launcher.application.impl.SystemPropertyConfigLoader

--- a/application/src/test/java/io/vertx/launcher/application/tests/CustomConfigLoaderTest.java
+++ b/application/src/test/java/io/vertx/launcher/application/tests/CustomConfigLoaderTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.launcher.application.tests;
+
+import io.vertx.core.VertxOptions;
+import io.vertx.launcher.application.ConfigScope;
+import io.vertx.launcher.application.HookContext;
+import io.vertx.launcher.application.VertxApplication;
+import io.vertx.launcher.application.VertxApplicationHooks;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariables;
+
+public class CustomConfigLoaderTest {
+
+  private TestHooks hooks;
+
+  @BeforeEach
+  void setUp() {
+    TestVerticle.instanceCount.set(0);
+    TestVerticle.conf = null;
+    TestConfigLoader.reset();
+    TestConfigLoader.enabled = true;
+    hooks = new TestHooks();
+  }
+
+  @AfterEach
+  void tearDown() {
+    TestConfigLoader.reset();
+    if (hooks != null && hooks.vertx != null) {
+      CompletableFuture<Void> future = hooks.vertx.close().toCompletionStage().toCompletableFuture();
+      await("Failure to close Vert.x").atMost(Duration.ofSeconds(10)).until(future::isDone);
+    }
+  }
+
+  @Test
+  public void testCustomConfigLoaderIsInvoked() {
+    TestConfigLoader.eventLoopPoolSize = 77;
+
+    AtomicReference<VertxOptions> vertxOptions = new AtomicReference<>();
+    hooks = new TestHooks() {
+      @Override
+      public void beforeStartingVertx(HookContext context) {
+        vertxOptions.set(context.vertxOptions());
+      }
+    };
+
+    TestVertxApplication app = new TestVertxApplication(new String[] { "java:" + TestVerticle.class.getCanonicalName() }, hooks);
+
+    app.launch();
+
+    await("Server not started")
+      .atMost(Duration.ofSeconds(10))
+      .until(() -> TestVerticle.instanceCount.get(), equalTo(1));
+
+    assertEquals(77, vertxOptions.get().getEventLoopPoolSize());
+    assertTrue(TestConfigLoader.invocations.contains(ConfigScope.VERTX));
+  }
+
+  @Test
+  public void testCustomConfigLoaderOrder() throws Exception {
+    // Custom loader (order=1500) sets eventLoopPoolSize=77
+    // Env vars (order=1000) set eventLoopPoolSize=42
+    // Custom loader should win because it has higher order (applied later)
+    TestConfigLoader.eventLoopPoolSize = 77;
+
+    AtomicReference<VertxOptions> vertxOptions = new AtomicReference<>();
+    hooks = new TestHooks() {
+      @Override
+      public void beforeStartingVertx(HookContext context) {
+        vertxOptions.set(context.vertxOptions());
+      }
+    };
+
+    withEnvironmentVariables("VERTX_OPTIONS_EVENT_LOOP_POOL_SIZE", "42")
+      .execute(() -> {
+        TestVertxApplication app = new TestVertxApplication(new String[] { "java:" + TestVerticle.class.getCanonicalName() }, hooks);
+        app.launch();
+      });
+
+    await("Server not started")
+      .atMost(Duration.ofSeconds(10))
+      .until(() -> TestVerticle.instanceCount.get(), equalTo(1));
+
+    assertEquals(77, vertxOptions.get().getEventLoopPoolSize());
+  }
+
+  @Test
+  public void testSystemPropertiesOverrideCustomConfigLoader() {
+    // Custom loader (order=1500) sets eventLoopPoolSize=77
+    // System properties (order=2000) set eventLoopPoolSize=99
+    // System properties should win because they have higher order
+    TestConfigLoader.eventLoopPoolSize = 77;
+
+    AtomicReference<VertxOptions> vertxOptions = new AtomicReference<>();
+    hooks = new TestHooks() {
+      @Override
+      public void beforeStartingVertx(HookContext context) {
+        vertxOptions.set(context.vertxOptions());
+      }
+    };
+
+    try {
+      System.setProperty("vertx.options.eventLoopPoolSize", "99");
+      TestVertxApplication app = new TestVertxApplication(new String[] { "java:" + TestVerticle.class.getCanonicalName() }, hooks);
+      app.launch();
+    } finally {
+      System.clearProperty("vertx.options.eventLoopPoolSize");
+    }
+
+    await("Server not started")
+      .atMost(Duration.ofSeconds(10))
+      .until(() -> TestVerticle.instanceCount.get(), equalTo(1));
+
+    assertEquals(99, vertxOptions.get().getEventLoopPoolSize());
+  }
+
+  private static class TestVertxApplication extends VertxApplication {
+    public TestVertxApplication(String[] args, VertxApplicationHooks hooks) {
+      super(args, hooks, true, false);
+    }
+  }
+}

--- a/application/src/test/java/io/vertx/launcher/application/tests/TestConfigLoader.java
+++ b/application/src/test/java/io/vertx/launcher/application/tests/TestConfigLoader.java
@@ -1,0 +1,38 @@
+package io.vertx.launcher.application.tests;
+
+import io.vertx.core.VertxOptions;
+import io.vertx.launcher.application.ConfigLoader;
+import io.vertx.launcher.application.ConfigScope;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class TestConfigLoader implements ConfigLoader {
+
+  static volatile boolean enabled;
+  static final List<ConfigScope> invocations = Collections.synchronizedList(new ArrayList<>());
+  static volatile int eventLoopPoolSize = -1;
+
+  static void reset() {
+    enabled = false;
+    invocations.clear();
+    eventLoopPoolSize = -1;
+  }
+
+  @Override
+  public int order() {
+    return 1500;
+  }
+
+  @Override
+  public void configure(Object target, ConfigScope scope) {
+    if (!enabled) {
+      return;
+    }
+    invocations.add(scope);
+    if (eventLoopPoolSize > 0 && scope == ConfigScope.VERTX && target instanceof VertxOptions) {
+      ((VertxOptions) target).setEventLoopPoolSize(eventLoopPoolSize);
+    }
+  }
+}

--- a/application/src/test/java/module-info.java
+++ b/application/src/test/java/module-info.java
@@ -20,4 +20,6 @@ open module io.vertx.launcher.application.tests {
   // Only required for compilation
   requires static io.vertx.core.tests;
   requires static awaitility;
+
+  provides io.vertx.launcher.application.ConfigLoader with io.vertx.launcher.application.tests.TestConfigLoader;
 }

--- a/application/src/test/resources/META-INF/services/io.vertx.launcher.application.ConfigLoader
+++ b/application/src/test/resources/META-INF/services/io.vertx.launcher.application.ConfigLoader
@@ -1,0 +1,1 @@
+io.vertx.launcher.application.tests.TestConfigLoader


### PR DESCRIPTION
Motivation:

Configuration was hardcoded to environment variables and system properties with no way to extend it. Users wanting to load config from other sources (AWS AppConfig, Firebase Remote Config, etc.) had to work around the launcher entirely.

Changes:

- Add ConfigLoader interface and ConfigScope enum as a public SPI, discovered via ServiceLoader and sorted by order
- Extract existing env var and system property logic into default ConfigLoader implementations backed by a shared AbstractConfigLoader
- Refactor VertxApplicationCommand to use the loader chain
- Add tests for custom loader discovery, ordering, and precedence
- Document the SPI in index.adoc with an example

Closes: #35 