### PR TITLE
Make startup, deployment and shutdown timeouts configurable

### DIFF
--- a/application/src/main/java/io/vertx/launcher/application/impl/ShutdownHook.java
+++ b/application/src/main/java/io/vertx/launcher/application/impl/ShutdownHook.java
@@ -26,10 +26,12 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class ShutdownHook implements Runnable {
 
   private final Vertx vertx;
+  private final Duration timeout;
   private final Consumer<AsyncResult<Void>> whenComplete;
 
-  public ShutdownHook(Vertx vertx, Consumer<AsyncResult<Void>> whenComplete) {
+  public ShutdownHook(Vertx vertx, Duration timeout, Consumer<AsyncResult<Void>> whenComplete) {
     this.vertx = vertx;
+    this.timeout = timeout;
     this.whenComplete = whenComplete;
   }
 
@@ -46,7 +48,7 @@ public class ShutdownHook implements Runnable {
 
   private AsyncResult<Void> closeVertx() throws ExecutionException, TimeoutException {
     CompletableFuture<Void> future = vertx.close().toCompletionStage().toCompletableFuture();
-    long remaining = Duration.ofMinutes(2).toMillis();
+    long remaining = timeout.toMillis();
     long stop = System.currentTimeMillis() + remaining;
     boolean interrupted = false;
     while (true) {

--- a/application/src/main/java/io/vertx/launcher/application/impl/VertxApplicationCommand.java
+++ b/application/src/main/java/io/vertx/launcher/application/impl/VertxApplicationCommand.java
@@ -55,6 +55,12 @@ public class VertxApplicationCommand implements Runnable {
   static final String DEPLOYMENT_OPTIONS_ENV_PREFIX = "VERTX_DEPLOYMENT_OPTIONS_";
   static final String METRICS_OPTIONS_ENV_PREFIX = "VERTX_METRICS_OPTIONS_";
 
+  static final String VERTX_STARTUP_TIMEOUT_SECONDS_ENV = "VERTX_STARTUP_TIMEOUT_SECONDS";
+  static final String VERTX_DEPLOYMENT_TIMEOUT_SECONDS_ENV = "VERTX_DEPLOYMENT_TIMEOUT_SECONDS";
+  static final String VERTX_SHUTDOWN_TIMEOUT_SECONDS_ENV = "VERTX_SHUTDOWN_TIMEOUT_SECONDS";
+
+  private static final long DEFAULT_TIMEOUT_SECONDS = 120;
+
   @Option(
     names = {"-options", "--options", "-vertx-options", "--vertx-options"},
     description = {
@@ -162,6 +168,42 @@ public class VertxApplicationCommand implements Runnable {
   private String configStr;
 
   @Option(
+    names = {"--startup-timeout-seconds"},
+    description = {
+      "Timeout in seconds for Vert.x startup.",
+      "Can also be set via the " + VERTX_STARTUP_TIMEOUT_SECONDS_ENV + " environment variable.",
+      "Default: 120."
+    },
+    defaultValue = Option.NULL_VALUE
+  )
+  @SuppressWarnings("unused")
+  private Long startupTimeoutSeconds;
+
+  @Option(
+    names = {"--deployment-timeout-seconds"},
+    description = {
+      "Timeout in seconds for main verticle deployment.",
+      "Can also be set via the " + VERTX_DEPLOYMENT_TIMEOUT_SECONDS_ENV + " environment variable.",
+      "Default: 120."
+    },
+    defaultValue = Option.NULL_VALUE
+  )
+  @SuppressWarnings("unused")
+  private Long deploymentTimeoutSeconds;
+
+  @Option(
+    names = {"--shutdown-timeout-seconds"},
+    description = {
+      "Timeout in seconds for Vert.x shutdown.",
+      "Can also be set via the " + VERTX_SHUTDOWN_TIMEOUT_SECONDS_ENV + " environment variable.",
+      "Default: 120."
+    },
+    defaultValue = Option.NULL_VALUE
+  )
+  @SuppressWarnings("unused")
+  private Long shutdownTimeoutSeconds;
+
+  @Option(
     names = {"-h", "-help", "--help"},
     usageHelp = true,
     description = {
@@ -209,14 +251,18 @@ public class VertxApplicationCommand implements Runnable {
     VertxBuilder builder = hooks.createVertxBuilder(options);
     processVertxOptions(options, optionsParam);
 
+    Duration startupTimeout = Duration.ofSeconds(resolveTimeout(VERTX_STARTUP_TIMEOUT_SECONDS_ENV, startupTimeoutSeconds));
+    Duration deploymentTimeout = Duration.ofSeconds(resolveTimeout(VERTX_DEPLOYMENT_TIMEOUT_SECONDS_ENV, deploymentTimeoutSeconds));
+    Duration shutdownTimeout = Duration.ofSeconds(resolveTimeout(VERTX_SHUTDOWN_TIMEOUT_SECONDS_ENV, shutdownTimeoutSeconds));
+
     hookContext.setVertxOptions(options);
     hooks.beforeStartingVertx(hookContext);
-    vertx = (VertxInternal) withTCCLAwait(() -> createVertx(builder), Duration.ofMinutes(2), "startup", VertxApplicationHooks::afterFailureToStartVertx, ExitCodes.VERTX_INITIALIZATION);
+    vertx = (VertxInternal) withTCCLAwait(() -> createVertx(builder), startupTimeout, "startup", VertxApplicationHooks::afterFailureToStartVertx, ExitCodes.VERTX_INITIALIZATION);
     hookContext.setVertx(vertx);
     hooks.afterVertxStarted(hookContext);
 
     vertx.addCloseHook(this::beforeStoppingVertx);
-    Runtime.getRuntime().addShutdownHook(new Thread(new ShutdownHook(vertx, this::afterShutdownHookExecuted)));
+    Runtime.getRuntime().addShutdownHook(new Thread(new ShutdownHook(vertx, shutdownTimeout, this::afterShutdownHookExecuted)));
 
     DeploymentOptions deploymentOptions = createDeploymentOptions(deploymentOptionsParam, conf);
 
@@ -237,7 +283,7 @@ public class VertxApplicationCommand implements Runnable {
 
     hooks.beforeDeployingVerticle(hookContext);
     String message = hookContext.deploymentOptions().getThreadingModel() == ThreadingModel.WORKER ? "deploying worker verticle" : "deploying verticle";
-    String deploymentId = withTCCLAwait(deployer, Duration.ofMinutes(2), message, VertxApplicationHooks::afterFailureToDeployVerticle, ExitCodes.VERTX_DEPLOYMENT);
+    String deploymentId = withTCCLAwait(deployer, deploymentTimeout, message, VertxApplicationHooks::afterFailureToDeployVerticle, ExitCodes.VERTX_DEPLOYMENT);
     log.info("Succeeded in " + message);
     hookContext.setDeploymentId(deploymentId);
     hooks.afterVerticleDeployed(hookContext);
@@ -344,6 +390,21 @@ public class VertxApplicationCommand implements Runnable {
       log.error("Failed to create the Vert.x instance", e);
       return Future.failedFuture(e);
     }
+  }
+
+  private long resolveTimeout(String envVar, Long cliValue) {
+    if (cliValue != null) {
+      return cliValue;
+    }
+    String envValue = System.getenv(envVar);
+    if (envValue != null) {
+      try {
+        return Long.parseLong(envValue);
+      } catch (NumberFormatException e) {
+        log.warn("Invalid value for environment variable " + envVar + ": \"" + envValue + "\". Using default: " + DEFAULT_TIMEOUT_SECONDS + "s.");
+      }
+    }
+    return DEFAULT_TIMEOUT_SECONDS;
   }
 
   private <T> T withTCCLAwait(Supplier<Future<T>> supplier, Duration duration, String logMessage, FailureHook failureHook, int exitCode) {

--- a/application/src/main/java/io/vertx/launcher/application/impl/VertxApplicationCommand.java
+++ b/application/src/main/java/io/vertx/launcher/application/impl/VertxApplicationCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -171,6 +171,7 @@ public class VertxApplicationCommand implements Runnable {
     names = {"--startup-timeout-seconds"},
     description = {
       "Timeout in seconds for Vert.x startup.",
+      "Must be a positive number.",
       "Can also be set via the " + VERTX_STARTUP_TIMEOUT_SECONDS_ENV + " environment variable.",
       "Default: 120."
     },
@@ -183,6 +184,7 @@ public class VertxApplicationCommand implements Runnable {
     names = {"--deployment-timeout-seconds"},
     description = {
       "Timeout in seconds for main verticle deployment.",
+      "Must be a positive number.",
       "Can also be set via the " + VERTX_DEPLOYMENT_TIMEOUT_SECONDS_ENV + " environment variable.",
       "Default: 120."
     },
@@ -195,6 +197,7 @@ public class VertxApplicationCommand implements Runnable {
     names = {"--shutdown-timeout-seconds"},
     description = {
       "Timeout in seconds for Vert.x shutdown.",
+      "Must be a positive number.",
       "Can also be set via the " + VERTX_SHUTDOWN_TIMEOUT_SECONDS_ENV + " environment variable.",
       "Default: 120."
     },
@@ -394,15 +397,29 @@ public class VertxApplicationCommand implements Runnable {
 
   private long resolveTimeout(String envVar, Long cliValue) {
     if (cliValue != null) {
+      if (cliValue <= 0) {
+        log.warn(String.format("Invalid CLI timeout value: %d. Must be positive. Using default: %ds.", cliValue, DEFAULT_TIMEOUT_SECONDS));
+        return DEFAULT_TIMEOUT_SECONDS;
+      }
       return cliValue;
     }
     String envValue = System.getenv(envVar);
-    if (envValue != null) {
-      try {
-        return Long.parseLong(envValue);
-      } catch (NumberFormatException e) {
-        log.warn("Invalid value for environment variable " + envVar + ": \"" + envValue + "\". Using default: " + DEFAULT_TIMEOUT_SECONDS + "s.");
+    if (envValue == null) {
+      return DEFAULT_TIMEOUT_SECONDS;
+    }
+    if (envValue.isBlank()) {
+      log.warn(String.format("Invalid value for environment variable %s: empty string. Using default: %ds.", envVar, DEFAULT_TIMEOUT_SECONDS));
+      return DEFAULT_TIMEOUT_SECONDS;
+    }
+    try {
+      long parsedValue = Long.parseLong(envValue.trim());
+      if (parsedValue <= 0) {
+        log.warn(String.format("Invalid value for environment variable %s: \"%s\". Must be positive. Using default: %ds.", envVar, envValue, DEFAULT_TIMEOUT_SECONDS));
+        return DEFAULT_TIMEOUT_SECONDS;
       }
+      return parsedValue;
+    } catch (NumberFormatException e) {
+      log.warn(String.format("Invalid value for environment variable %s: \"%s\". Not a valid number. Using default: %ds.", envVar, envValue, DEFAULT_TIMEOUT_SECONDS));
     }
     return DEFAULT_TIMEOUT_SECONDS;
   }

--- a/application/src/test/java/io/vertx/launcher/application/tests/TimeoutTest.java
+++ b/application/src/test/java/io/vertx/launcher/application/tests/TimeoutTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.launcher.application.tests;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+import io.vertx.launcher.application.VertxApplication;
+import io.vertx.launcher.application.VertxApplicationHooks;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+import static io.vertx.launcher.application.ExitCodes.VERTX_DEPLOYMENT;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariables;
+
+public class TimeoutTest {
+
+  private TestHooks hooks;
+
+  @BeforeEach
+  void setUp() {
+    hooks = new TestHooks();
+    TestVerticle.instanceCount.set(0);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (hooks.vertx != null) {
+      CompletableFuture<Void> future = hooks.vertx.close().toCompletionStage().toCompletableFuture();
+      await("Failure to close Vert.x")
+        .atMost(Duration.ofSeconds(10))
+        .until(future::isDone);
+    }
+  }
+
+  @Test
+  void testDefaultTimeoutsStartApplicationSuccessfully() {
+    new TestVertxApplication(new String[]{"java:" + TestVerticle.class.getCanonicalName()}, hooks).launch();
+    await("Verticle not deployed")
+      .atMost(Duration.ofSeconds(10))
+      .until(TestVerticle.instanceCount::get, equalTo(1));
+  }
+
+  @Test
+  void testStartupTimeoutCliOption() {
+    new TestVertxApplication(
+      new String[]{"--startup-timeout-seconds", "10", "java:" + TestVerticle.class.getCanonicalName()}, hooks
+    ).launch();
+    await("Verticle not deployed")
+      .atMost(Duration.ofSeconds(10))
+      .until(TestVerticle.instanceCount::get, equalTo(1));
+  }
+
+  @Test
+  void testDeploymentTimeoutCliOption() {
+    new TestVertxApplication(
+      new String[]{"--deployment-timeout-seconds", "30", "java:" + TestVerticle.class.getCanonicalName()}, hooks
+    ).launch();
+    await("Verticle not deployed")
+      .atMost(Duration.ofSeconds(10))
+      .until(TestVerticle.instanceCount::get, equalTo(1));
+  }
+
+  @Test
+  void testShutdownTimeoutCliOption() {
+    new TestVertxApplication(
+      new String[]{"--shutdown-timeout-seconds", "5", "java:" + TestVerticle.class.getCanonicalName()}, hooks
+    ).launch();
+    await("Verticle not deployed")
+      .atMost(Duration.ofSeconds(10))
+      .until(TestVerticle.instanceCount::get, equalTo(1));
+  }
+
+  @Test
+  void testStartupTimeoutFromEnvVar() throws Exception {
+    withEnvironmentVariables("VERTX_STARTUP_TIMEOUT_SECONDS", "10").execute(() -> {
+      new TestVertxApplication(
+        new String[]{"java:" + TestVerticle.class.getCanonicalName()}, hooks
+      ).launch();
+    });
+    await("Verticle not deployed")
+      .atMost(Duration.ofSeconds(10))
+      .until(TestVerticle.instanceCount::get, equalTo(1));
+  }
+
+  @Test
+  void testDeploymentTimeoutFromEnvVar() throws Exception {
+    withEnvironmentVariables("VERTX_DEPLOYMENT_TIMEOUT_SECONDS", "30").execute(() -> {
+      new TestVertxApplication(
+        new String[]{"java:" + TestVerticle.class.getCanonicalName()}, hooks
+      ).launch();
+    });
+    await("Verticle not deployed")
+      .atMost(Duration.ofSeconds(10))
+      .until(TestVerticle.instanceCount::get, equalTo(1));
+  }
+
+  @Test
+  void testInvalidStartupTimeoutEnvVarFallsBackToDefault() throws Exception {
+    withEnvironmentVariables("VERTX_STARTUP_TIMEOUT_SECONDS", "not-a-number").execute(() -> {
+      new TestVertxApplication(
+        new String[]{"java:" + TestVerticle.class.getCanonicalName()}, hooks
+      ).launch();
+    });
+    await("Verticle not deployed")
+      .atMost(Duration.ofSeconds(10))
+      .until(TestVerticle.instanceCount::get, equalTo(1));
+  }
+
+  @Test
+  void testDeploymentTimeoutExpiryReturnsDeploymentExitCode() {
+    int exitCode = new TestVertxApplication(
+      new String[]{"--deployment-timeout-seconds", "1", "java:" + NeverDeployingVerticle.class.getName()}, hooks
+    ).launch();
+    assertEquals(VERTX_DEPLOYMENT, exitCode);
+  }
+
+  /**
+   * A verticle whose start promise is intentionally never completed, causing any deployment
+   * attempt to hang until the configured deployment timeout fires.
+   */
+  public static class NeverDeployingVerticle extends AbstractVerticle {
+    @Override
+    public void start(Promise<Void> startPromise) {
+      // Intentionally never complete the start promise so the deployment times out.
+    }
+  }
+
+  private static class TestVertxApplication extends VertxApplication {
+    TestVertxApplication(String[] args, VertxApplicationHooks hooks) {
+      super(args, hooks, true, false);
+    }
+  }
+}

--- a/application/src/test/java/io/vertx/launcher/application/tests/TimeoutTest.java
+++ b/application/src/test/java/io/vertx/launcher/application/tests/TimeoutTest.java
@@ -13,6 +13,7 @@ package io.vertx.launcher.application.tests;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
+import io.vertx.core.json.JsonObject;
 import io.vertx.launcher.application.VertxApplication;
 import io.vertx.launcher.application.VertxApplicationHooks;
 import org.junit.jupiter.api.AfterEach;
@@ -24,7 +25,6 @@ import java.util.concurrent.CompletableFuture;
 
 import static io.vertx.launcher.application.ExitCodes.VERTX_DEPLOYMENT;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariables;
 
@@ -49,95 +49,125 @@ public class TimeoutTest {
   }
 
   @Test
-  void testDefaultTimeoutsStartApplicationSuccessfully() {
-    new TestVertxApplication(new String[]{"java:" + TestVerticle.class.getCanonicalName()}, hooks).launch();
-    await("Verticle not deployed")
-      .atMost(Duration.ofSeconds(10))
-      .until(TestVerticle.instanceCount::get, equalTo(1));
+  void testNegativeStartupTimeoutCliOptionFallsBackToDefault() {
+    testInvalidCliOptionFallsBackToDefault("-10");
   }
 
   @Test
-  void testStartupTimeoutCliOption() {
-    new TestVertxApplication(
-      new String[]{"--startup-timeout-seconds", "10", "java:" + TestVerticle.class.getCanonicalName()}, hooks
+  void testZeroStartupTimeoutCliOptionFallsBackToDefault() {
+    testInvalidCliOptionFallsBackToDefault("0");
+  }
+
+  private void testInvalidCliOptionFallsBackToDefault(String value) {
+    JsonObject config = new JsonObject().put(DelayedStartVerticle.DELAY_MS_CONFIG_KEY, 500L);
+    int exitCode = new TestVertxApplication(
+      new String[]{
+        "--startup-timeout-seconds", value,
+        "--conf", config.encode(),
+        "java:" + DelayedStartVerticle.class.getName()
+      },
+      hooks
     ).launch();
-    await("Verticle not deployed")
-      .atMost(Duration.ofSeconds(10))
-      .until(TestVerticle.instanceCount::get, equalTo(1));
+    assertEquals(0, exitCode);
   }
 
   @Test
-  void testDeploymentTimeoutCliOption() {
-    new TestVertxApplication(
-      new String[]{"--deployment-timeout-seconds", "30", "java:" + TestVerticle.class.getCanonicalName()}, hooks
-    ).launch();
-    await("Verticle not deployed")
-      .atMost(Duration.ofSeconds(10))
-      .until(TestVerticle.instanceCount::get, equalTo(1));
+  void testNegativeDeploymentTimeoutEnvVarFallsBackToDefault() throws Exception {
+    testInvalidEnvVarFallsBackToDefault("-5");
   }
 
   @Test
-  void testShutdownTimeoutCliOption() {
-    new TestVertxApplication(
-      new String[]{"--shutdown-timeout-seconds", "5", "java:" + TestVerticle.class.getCanonicalName()}, hooks
-    ).launch();
-    await("Verticle not deployed")
-      .atMost(Duration.ofSeconds(10))
-      .until(TestVerticle.instanceCount::get, equalTo(1));
+  void testZeroDeploymentTimeoutEnvVarFallsBackToDefault() throws Exception {
+    testInvalidEnvVarFallsBackToDefault("0");
   }
 
   @Test
-  void testStartupTimeoutFromEnvVar() throws Exception {
-    withEnvironmentVariables("VERTX_STARTUP_TIMEOUT_SECONDS", "10").execute(() -> {
-      new TestVertxApplication(
-        new String[]{"java:" + TestVerticle.class.getCanonicalName()}, hooks
-      ).launch();
-    });
-    await("Verticle not deployed")
-      .atMost(Duration.ofSeconds(10))
-      .until(TestVerticle.instanceCount::get, equalTo(1));
+  void testEmptyStringDeploymentTimeoutEnvVarFallsBackToDefault() throws Exception {
+    testInvalidEnvVarFallsBackToDefault("");
   }
 
   @Test
-  void testDeploymentTimeoutFromEnvVar() throws Exception {
-    withEnvironmentVariables("VERTX_DEPLOYMENT_TIMEOUT_SECONDS", "30").execute(() -> {
-      new TestVertxApplication(
-        new String[]{"java:" + TestVerticle.class.getCanonicalName()}, hooks
-      ).launch();
-    });
-    await("Verticle not deployed")
-      .atMost(Duration.ofSeconds(10))
-      .until(TestVerticle.instanceCount::get, equalTo(1));
+  void testWhitespaceDeploymentTimeoutEnvVarFallsBackToDefault() throws Exception {
+    testInvalidEnvVarFallsBackToDefault("   ");
   }
 
   @Test
   void testInvalidStartupTimeoutEnvVarFallsBackToDefault() throws Exception {
-    withEnvironmentVariables("VERTX_STARTUP_TIMEOUT_SECONDS", "not-a-number").execute(() -> {
-      new TestVertxApplication(
-        new String[]{"java:" + TestVerticle.class.getCanonicalName()}, hooks
+    testInvalidEnvVarFallsBackToDefault("not-a-number");
+  }
+
+  private void testInvalidEnvVarFallsBackToDefault(String value) throws Exception {
+    withEnvironmentVariables("VERTX_DEPLOYMENT_TIMEOUT_SECONDS", value).execute(() -> {
+      JsonObject config = new JsonObject().put(DelayedStartVerticle.DELAY_MS_CONFIG_KEY, 500L);
+      int exitCode = new TestVertxApplication(
+        new String[]{
+          "--conf", config.encode(),
+          "java:" + DelayedStartVerticle.class.getName()
+        },
+        hooks
       ).launch();
+      assertEquals(0, exitCode);
     });
-    await("Verticle not deployed")
-      .atMost(Duration.ofSeconds(10))
-      .until(TestVerticle.instanceCount::get, equalTo(1));
   }
 
   @Test
-  void testDeploymentTimeoutExpiryReturnsDeploymentExitCode() {
+  void testDeploymentTimeoutWithCliOption() {
+    JsonObject config = new JsonObject().put(DelayedStartVerticle.DELAY_MS_CONFIG_KEY, 5000L);
     int exitCode = new TestVertxApplication(
-      new String[]{"--deployment-timeout-seconds", "1", "java:" + NeverDeployingVerticle.class.getName()}, hooks
+      new String[]{
+        "--deployment-timeout-seconds", "1",
+        "--conf", config.encode(),
+        "java:" + DelayedStartVerticle.class.getName()
+      },
+      hooks
     ).launch();
     assertEquals(VERTX_DEPLOYMENT, exitCode);
   }
 
-  /**
-   * A verticle whose start promise is intentionally never completed, causing any deployment
-   * attempt to hang until the configured deployment timeout fires.
-   */
-  public static class NeverDeployingVerticle extends AbstractVerticle {
+  @Test
+  void testDeploymentTimeoutWithEnvVar() throws Exception {
+    JsonObject config = new JsonObject().put(DelayedStartVerticle.DELAY_MS_CONFIG_KEY, 5000L);
+    withEnvironmentVariables("VERTX_DEPLOYMENT_TIMEOUT_SECONDS", "1").execute(() -> {
+      int exitCode = new TestVertxApplication(
+        new String[]{
+          "--conf", config.encode(),
+          "java:" + DelayedStartVerticle.class.getName()
+        },
+        hooks
+      ).launch();
+      assertEquals(VERTX_DEPLOYMENT, exitCode);
+    });
+  }
+
+  @Test
+  void testCliValueOverridesEnvVar() throws Exception {
+    JsonObject config = new JsonObject().put(DelayedStartVerticle.DELAY_MS_CONFIG_KEY, 5000L);
+    withEnvironmentVariables("VERTX_DEPLOYMENT_TIMEOUT_SECONDS", "10").execute(() -> {
+      int exitCode = new TestVertxApplication(
+        new String[]{
+          "--deployment-timeout-seconds", "1",
+          "--conf", config.encode(),
+          "java:" + DelayedStartVerticle.class.getName()
+        },
+        hooks
+      ).launch();
+      assertEquals(VERTX_DEPLOYMENT, exitCode);
+    });
+  }
+
+  public static class DelayedStartVerticle extends AbstractVerticle {
+    static final String DELAY_MS_CONFIG_KEY = "delayMs";
+
     @Override
     public void start(Promise<Void> startPromise) {
-      // Intentionally never complete the start promise so the deployment times out.
+      long delayMs = config().getLong(DELAY_MS_CONFIG_KEY, 0L);
+      if (delayMs <= 0) {
+        startPromise.complete();
+        return;
+      }
+      vertx.setTimer(delayMs, id -> {
+        startPromise.complete();
+      });
     }
   }
 


### PR DESCRIPTION
Motivation:

At the moment it appears there is a hardcoded timeout of 2 minutes for vertx startup, main verticle deployment and vertx shutdown.

Closes: [#36 ](https://github.com/eclipse-vertx/vertx-launcher/issues/36)